### PR TITLE
Fix node versioning

### DIFF
--- a/program.ts
+++ b/program.ts
@@ -1,4 +1,4 @@
-if (Number(process.version.slice(1).split(".")[0]) < 12.11.1) throw new Error("Node 12.11.1 or higher is required. Update Node on your system.");
+if (Number(process.version.slice(1).split(".")[0]) < 12) throw new Error("Node 12.x or higher is required. Update Node on your system.");
 process.title = 'FarmCord'
 // Imports and stuff
 


### PR DESCRIPTION
Basically fixes node versioning.
JavaScript doesn't provide `double` (decimal)-like values, that's why it was prolly crashing